### PR TITLE
Feat/Specify the `mode` for display in the table-dataset

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -193,7 +193,7 @@ watch(animation, a => {
 const options = createOptions({
     title_function: (items: MyData[]) => {
         const unique = [...new Set(items.map(a => a.y))]
-        return `Days: ${unique.join(', ')}`;
+        return `${mode.value}: ${unique.join(', ')}`;
     },
     tooltip_function: (item: MyData) => {
         const review_text = item.review.join('');

--- a/src/App.vue
+++ b/src/App.vue
@@ -25,13 +25,17 @@
             <label for="mode-interval">Interval</label>
         </div>
         <div>
-            <input id="mode-cumulativeInterval" type="radio" :value="nameof<Card>('cumulativeInterval')"
-                v-model="mode" />
-            <label for="mode-cumulativeInterval">Cumulative</label>
+            <input id="mode-stability" type="radio" :value="nameof<Card>('stability')" v-model="mode" />
+            <label for="mode-stability">Stability</label>
         </div>
         <div>
             <input id="mode-displayDifficulty" type="radio" :value="nameof<Card>('displayDifficulty')" v-model="mode" />
             <label for="mode-displayDifficulty">Difficulty</label>
+        </div>
+        <div>
+            <input id="mode-cumulativeInterval" type="radio" :value="nameof<Card>('cumulativeInterval')"
+                v-model="mode" />
+            <label for="mode-cumulativeInterval">CumulativeInterval</label>
         </div>
         <div>
             <input id="animation" type="checkbox" v-model="animation" />
@@ -48,12 +52,22 @@
         <Slider v-for="(slider, index) in sliders" :info="slider" v-model="fsrs_params.w[index]" v-on:change="commit" />
     </div>
     <table class="table-dataset">
-        <tr v-for="dataset in data.datasets">
-            <td>{{ dataset.label }}</td>
-            <td v-for="item in dataset.data">
-                {{ item.card.stability.toFixed(2) }}
-            </td>
-        </tr>
+        <thead>
+            <tr>
+                <td>Grade</td>
+                <td v-for="label in data.labels">
+                    {{ modeOf(mode) }}-{{ label }}
+                </td>
+            </tr>
+        </thead>
+        <tbody>
+            <tr v-for="dataset in data.datasets">
+                <td>{{ dataset.label }}</td>
+                <td v-for="item in dataset.data">
+                    {{ cardDataFormat(item.card, mode) }}
+                </td>
+            </tr>
+        </tbody>
     </table>
     <a href="https://github.com/open-spaced-repetition/anki_fsrs_visualizer/" style="font-size: 75%;">Github</a>
 </template>
@@ -100,6 +114,7 @@ textarea {
 
 .table-dataset {
     border-collapse: collapse;
+    margin-top: 4px;
 }
 
 .table-dataset tr:nth-child(even) {
@@ -109,6 +124,7 @@ textarea {
 .table-dataset td {
     border: 1px solid #ddd;
     text-align: right;
+    padding: 4px;
 }
 </style>
 
@@ -139,7 +155,29 @@ ChartJS.register(Title, Tooltip, Legend, PointElement, LineElement, CategoryScal
 
 function nameof<T>(name: keyof T) { return name; }
 
-const mode = ref<keyof Card>('interval');
+function modeOf(mode: keyof Card) {
+    if (mode === 'interval') {
+        return 'Ivl';
+    } else if (mode === 'stability') {
+        return 'S';
+    } else if (mode === 'displayDifficulty') {
+        return 'D';
+    } else if (mode === 'cumulativeInterval') {
+        return 'CIvl';
+    } else {
+        return '';
+    }
+}
+
+function cardDataFormat(card: Card, mode: keyof Card) {
+    if (mode === 'interval' || mode === 'cumulativeInterval') {
+        return card[mode].toFixed(0);
+    } else {
+        return card[mode].toFixed(2)
+    }
+}
+
+const mode = ref<keyof Card>("interval");
 const animation = ref(true);
 const names = ['', 'Again', 'Hard', 'Good', 'Easy'];
 

--- a/src/tsFsrsCalculator.ts
+++ b/src/tsFsrsCalculator.ts
@@ -40,7 +40,7 @@ export class TsFsrsCalculator {
             const displayDifficulty = this.calcDisplayDifficulty(fsrs_card.difficulty);
             const interval = fsrs_card.scheduled_days;
             const cumulativeInterval = card.cumulativeInterval + interval;
-
+            card.cumulativeInterval = cumulativeInterval;
             list.push(new Card(fsrs_card.state, fsrs_card.difficulty, displayDifficulty, fsrs_card.stability, interval, cumulativeInterval, review));
         }
 


### PR DESCRIPTION
The table-dataset data is displayed according to the selected mode.

Interval:
![image](https://github.com/user-attachments/assets/74a8aa10-89c5-47dc-be23-cc84b56b36cc)

Stability:
![image](https://github.com/user-attachments/assets/9cc32bf9-3779-4103-ab2d-ad6f486db7c0)

Difficulty:
![image](https://github.com/user-attachments/assets/892528e7-5ed3-4234-b099-c998f0301cfd)

CumulativeInterval:
![image](https://github.com/user-attachments/assets/789aafe1-d960-46dc-ac2e-630aab32fe2f)
