### PR TITLE
Add a Daily Load option toggle

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -31,11 +31,16 @@
             <input id="mode-displayDifficulty" type="radio" :value="nameof<Card>('displayDifficulty')" v-model="mode" />
             <label for="mode-displayDifficulty">Difficulty</label>
         </div>
-        <div>
-            <input id="mode-cumulativeInterval" type="radio" :value="nameof<Card>('cumulativeInterval')"
-                v-model="mode" />
-            <label for="mode-cumulativeInterval">CumulativeInterval</label>
-        </div>
+      <div>
+        <input id="mode-cumulativeInterval" type="radio" :value="nameof<Card>('cumulativeInterval')"
+               v-model="mode" />
+        <label for="mode-cumulativeInterval">CumulativeInterval</label>
+      </div>
+      <div>
+        <input id="mode-load" type="radio" :value="nameof<Card>('dailyLoad')"
+               v-model="mode" />
+        <label for="mode-load">Daily Load (%)</label>
+      </div>
         <div>
             <input id="animation" type="checkbox" v-model="animation" />
             <label for="animation">Animation</label>

--- a/src/tsFsrsCalculator.ts
+++ b/src/tsFsrsCalculator.ts
@@ -15,6 +15,10 @@ export class TsFsrsCalculator {
         return (d - 1.0) / 9.0 * 100.0;
     }
 
+    calcDailyLoad(interval: number) {
+        return Math.round(1 / (interval ?? 1) * 10000.0) / 100.00;
+    }
+
     public steps(reviews: number[]): Card[] {
         let fsrs_card = createEmptyCard(new Date());
         const list = [];
@@ -37,8 +41,9 @@ export class TsFsrsCalculator {
 
             const displayDifficulty = this.calcDisplayDifficulty(fsrs_card.difficulty);
             const interval = fsrs_card.scheduled_days;
+            const dailyLoad = this.calcDailyLoad(interval)
             cumulativeInterval += interval;
-            list.push(new Card(fsrs_card.state, fsrs_card.difficulty, displayDifficulty, fsrs_card.stability, interval, cumulativeInterval, review));
+            list.push(new Card(fsrs_card.state, fsrs_card.difficulty, displayDifficulty, fsrs_card.stability, interval, dailyLoad, cumulativeInterval, review));
         }
 
         return list;
@@ -51,15 +56,17 @@ export class Card {
     displayDifficulty: number;
     stability: number;
     interval: number;
+    dailyLoad: number;
     cumulativeInterval: number;
     grade: number;
 
-    public constructor(state: number, difficulty: number, displayDifficulty: number, stability: number, interval: number, cumulativeInterval: number, grade: number) {
+    public constructor(state: number, difficulty: number, displayDifficulty: number, stability: number, interval: number, dailyLoad: number, cumulativeInterval: number, grade: number) {
         this.state = state;
         this.difficulty = difficulty;
         this.displayDifficulty = displayDifficulty;
         this.stability = stability;
         this.interval = interval;
+        this.dailyLoad = dailyLoad;
         this.cumulativeInterval = cumulativeInterval;
         this.grade = grade;
     }


### PR DESCRIPTION
<img width="2551" alt="CleanShot 2025-04-13 at 12 40 40@2x" src="https://github.com/user-attachments/assets/532cf430-3daa-4df1-b979-628108594f19" />

Hello, something that interests me those days is load management, and how cards through review reduce their load footprints.

To be able to reflect that in this visualizer, I created this branch/proof of concept.

Any thoughts ?